### PR TITLE
Asset Manager for Blender [0.2.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,27 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2024-02-22
+
+### Added
+- Added `Login` and `Logout` buttons to `Unity Cloud` menu.
+- Added functionality to select and update an asset in current project.
+- Leading and trailing spaces in asset name input string are now removed to comply with validation rules.
+
+### Fixed
+- Plugin now recalls previously selected organization and project ids.
+- Plugin recalls previously selected organization, project and asset ids only if they are available.
+- Removed reference to `InteropException`.
+
+### Changed
+- Updated a few URLs in the documentation.
+- `unity-cloud` is initialized/uninitialized on add-on registration/unregistration.
+- Previously selected organization, project and asset ids are reset after logging out.
+- AM4B is now using Unity Cloud Python SDK 0.5.0
+
 ## [0.1.1] - 2023-11-30
 
 ### Changed
-
 - AM4B is now using Unity Cloud Python SDK 0.2.2
 
 ## [0.1.0] - 2023-11-15
@@ -16,8 +33,8 @@ Initial release
 
 Features:
 - Source code of "Asset Manager for Blender" add-on that demonstrates how to:
-    - intall Unity Cloud Python SDK in integration environment;
-    - initialize and unititialize unity-cloud package;
+    - install Unity Cloud Python SDK in integration environment;
+    - initialize and uninitialize unity-cloud package;
     - login to Asset Manager using Unity Cloud Python SDK;
     - create new asset and upload data to it.
 - Python script to create a ready-to-install Blender add-on.

--- a/Documentation/Images/login.png
+++ b/Documentation/Images/login.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dac6eb17fbc43c017a87bbd286bfc464407e962203716a5be151e126780266c5
+size 332014

--- a/Documentation/Images/logout.png
+++ b/Documentation/Images/logout.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1fe97ea620aee386036ac45bdf714cc446dc42aeb8d0366947a358bb30769650
+size 325834

--- a/Documentation/Images/logout_complete.png
+++ b/Documentation/Images/logout_complete.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58324bd56b517cb561d7e0e6a411d3e1278fbc86737d2bd0e674ae5fbe31d07f
+size 11639

--- a/Documentation/Images/open_addon.png
+++ b/Documentation/Images/open_addon.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ee7c535c85a2e293e13f363cd2b0eeec50c5463c92363bd1d7ea55fda0caf056
-size 333331
+oid sha256:9a9c80ed08fea345f03a6cde14e4150a453f06d6e096cd1345310b9ccf6c11fa
+size 325953

--- a/Documentation/Images/popup.png
+++ b/Documentation/Images/popup.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c2d00d8bc7febd2c8a8b56a9afbf2347f89e17083c6586da0dfff03e99fd0e56
-size 13814
+oid sha256:d272a684fc592457b42b4c35a1efb1a19c1c556c3d21d33bd3fc0c07fd1c81dc
+size 14103

--- a/Documentation/Images/popup_update.png
+++ b/Documentation/Images/popup_update.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbd3ac931a81dc246f99004f2c37637c60a280a87c2b8e37982a6540e0942706
+size 16019

--- a/Documentation/technical-overview.md
+++ b/Documentation/technical-overview.md
@@ -9,11 +9,14 @@ This document will describe the structure of the "Asset Manager for Blender", ex
   - [Add-on structure](#add-on-structure)
   - [Add-on registration](#add-on-registration)
   - [Installing Unity Cloud Python SDK in Blender's python runtime](#installing-unity-cloud-python-sdk-in-blenders-python-runtime)
+  - [Initialization of Unity Cloud Python SDK](#initialization-of-unity-cloud-python-sdk)
   - [Interface](#interface)
     - [Add-on menu](#add-on-menu)
+    - [Login](#login)
+    - [Logout](#logout)
     - [Add-on dialog](#add-on-dialog)
   - [Listing organizations and projects](#listing-organizations-and-projects)
-  - [Asset creation](#asset-creation)
+  - [Uploading data to Asset Manager](#uploading-data-to-asset-manager)
     - [Asset data generation](#asset-data-generation)
     - [Asset data uploading](#asset-data-uploading)
   - [See also](#see-also)
@@ -43,13 +46,19 @@ AM4B contains 4 files:
 
 To install Unity Cloud Python SDK, `__init.py__.register()` executes `install_unity_cloud()` function of `uc_wheel_installation` module. The function identifies the current operating system, checks if it is supported by Unity Cloud Python SDK, selects an according Python wheel file in the add-on zip, and installs it using `pip` command.
 
+## Initialization of Unity Cloud Python SDK
+
+To initialize Unity Cloud Python SDK, `__init.py__.register()` executes `initialize()` function of `uc_asset_manager` module. The function initializes Unity Cloud Python SDK and configures it to use user login. This operation is performed when add-on was enabled, or when Blender starts.
+To uninitialize, `__init.py__.unregister()` executes `uninitialize()` function of `uc_asset_manager` module. This operation is performed when add-on was disabled, or when Blender is closing.
 
 ## Interface
 
-To define interface of AM4B `__init__.py` implements `UC_Category` and `ExportToCloudOperator` classes, and `draw_func()` function:
+To define interface of AM4B `__init__.py` implements `UC_Category` and `UploadToCloudOperator` classes, and `draw_func()` function:
 - `draw_func()` function displays add-on menu;
-- `UC_Category` class describes add-on menu structure and defines menu item functionality;
-- `ExportToCloudOperator` class describes add-on
+- `UC_Category` class describes add-on menu structure and defines menu items functionality;
+- `LoginToCloudOperator` class describes functionality of "Login" menu item;
+- `LogoutFromCloudOperator` class describes functionality of "Logout" menu item;
+- `UploadToCloudOperator` class describes functionality of "Upload FBX to Asset Manager" menu item. 
 
 These classes and function must be registered in Blender to display add-on when it is enabled, and unregistered to hide - when disabled.
 
@@ -60,31 +69,46 @@ Add-on menu items are defined with `UC_Category` class and `draw_func` function.
 
 `UC_Category` class describes the add-on menu and sub-menu items. It provides labels for menu items and define what happens when clicked.
 
+### Login
+
+When `Unity Cloud`->`Login` menu is clicked, the add-on will try to perform login to Unity Asset Manager using Unity Cloud Python SDK `identity` module. This functionality is defined in `LoginToCloudOperator` class. See [Blender Documentation. Operators](https://docs.blender.org/api/current/bpy.ops.html) for more information about custom operators in Blender.  
+
+### Logout
+
+When `Unity Cloud`->`Logout` menu is clicked, the add-on will try to perform logout from Unity Asset Manager using Unity Cloud Python SDK `identity` module. This functionality is defined in `LogoutFromCloudOperator` class. See [Blender Documentation. Operators](https://docs.blender.org/api/current/bpy.ops.html) for more information about custom operators in Blender.
+
 ### Add-on dialog
 
-When `Unity Cloud`->`Upload FBX to Asset Manager` menu is clicked, the `Upload FBX to Asset Manager` dialog opens. The UI and functionality of the dialog is defined by `ExportToCloudOperator` class. See [Blender Documentation. Operators](https://docs.blender.org/api/current/bpy.ops.html) for more information about custom operators in Blender.
+When `Unity Cloud`->`Upload FBX to Asset Manager` menu is clicked, the `Upload FBX to Asset Manager` dialog opens. The UI and functionality of the dialog is defined by `UploadToCloudOperator` class. See [Blender Documentation. Operators](https://docs.blender.org/api/current/bpy.ops.html) for more information about custom operators in Blender.
 
 See [Blender Documentation. Property definitions](https://docs.blender.org/api/current/bpy.props.html) and [Window Manager](https://docs.blender.org/api/current/bpy.types.WindowManager.html) for more details about custom dialogs in Blender.
 
-## Listing organizations and projects
+## Listing organizations, projects and assets
 
-As mentioned above, access to Asset Manager is provided by `uc_asset_manager` module which uses Unity Cloud Python SDK. The module should be initialized before usage, and uninitialized when it's not in use. The `ExportToCloudOperator` dialog initializes `uc_asset_manager` module and performs login every time when dialog is opened, and uninitializes when dialog is closed.
+As mentioned above, access to Asset Manager is provided by `uc_asset_manager` module which uses Unity Cloud Python SDK. The module should be initialized before usage, and uninitialized when it's not in use (See [Initialization of Unity Cloud Python SDK](#initialization-of-unity-cloud-python-sdk) for more information about initialization).
+`UploadToCloudOperator` prepares the list of the available organizations, projects and assets.
 
-Also, `ExportToCloudOperator` prepares the list of the available organizations and projects.
+## Uploading data to Asset Manager
 
-## Asset creation
-
-When user clicks "OK", `ExportToCloudOperator.execute()` function is called. It gathers information from user input, calls `uc_addon_execute` function from `uc_blender_utils` module, and uninitializes `uc_asset_manager` module.
+When user clicks "OK", `UploadToCloudOperator.execute()` function is called. It gathers information from user input, and calls `uc_create_asset` or `uc_update_asset` function from `uc_blender_utils` module depending on selected options.
 
 ### Asset data generation
 
-The first step of asset creation in AM4B is FBX file and optional thumbnail generation. `uc_blender_utils` module creates a temporary folder on disk, saves the current scene as fbx and thumbnail (if user chose to) in this folder using Python and Blender API. Then the data is sent to `uc_asset_manager` to be uploaded. The temp directory and files will be deleted after the upload:
+The first step of uploading to AM4B is FBX file and optional thumbnail generation. `uc_blender_utils` module creates a temporary folder on disk, saves the current scene as fbx and thumbnail (if user chose to) in this folder using Python and Blender API. Then the data is sent to `uc_asset_manager` to be uploaded. The temp directory and files will be deleted after the upload:
 
 See [Blender Documentation. Export scene operators](https://docs.blender.org/api/current/bpy.ops.export_scene.html#module-bpy.ops.export_scene) and [Render Operators](https://docs.blender.org/api/current/bpy.ops.render.html#module-bpy.ops.render) for information about exporting scene and creating images in Blender.
 
+### Asset creation
+
+If user chose to create a new asset, `uc_asset_manager.create_asset` will be executed. It creates a new asset in selected project using Unity Cloud Python SDK `assets` module.
+
+### Asset update
+
+If user chose to update an existing asset, `uc_asset_manager.update_asset` will be executed. It performs a request to update the selected asset with new information, and removes all the existing files from its datasets using Unity Cloud Python SDK `assets` module.
+
 ### Asset data uploading
 
-To upload a new asset to Asset Manager, `uc_asset_manager` creates a new asset in selected project, finds the default dataset and uploads the FBX file to the dataset. If user chose to generate a thumbnail, `uc_asset_manager` looks for "preview" dataset and uploads thumbnail to it. After files are uploaded, the add-on opens created asset in the system browser:
+After an asset is prepared for uploading new data, `uc_asset_manager` finds the default dataset and uploads the FBX file. If user chose to generate a thumbnail, `uc_asset_manager` looks for "preview" dataset and uploads thumbnail to it. After files are uploaded, the add-on opens the asset in the system browser using Unity Cloud Python SDK `interop` module.
 
 ## See also
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository open sources the code of that add-on, so that you can get inspir
 
 > **Note**: This repository does not accept pull requests, review requests, or any other GitHub-hosted issue management requests.
 
-To connect and find support, join the [Unity forum](https://forum.unity.com/forums/unity-cloud.868/)!
+To connect and find support, join the [Help & Support page](https://cloud.unity.com/home/dashboard-support)!
 
 ## Table of contents
 - [Asset Manager for Blender](#asset-manager-for-blender)
@@ -17,7 +17,10 @@ To connect and find support, join the [Unity forum](https://forum.unity.com/foru
   - [How do I...?](#how-do-i)
     - [Build the add-on](#build-the-add-on)
     - [Install the add-on](#install-the-add-on)
-    - [Publish the 3D view as an asset to Unity Cloud Asset Manager](#publish-the-3d-view-as-an-asset-to-unity-cloud-asset-manager)
+    - [Login to Unity Cloud Asset Manager](#login-to-unity-cloud-asset-manager)
+    - [Upload the 3D view as a new asset to Unity Cloud Asset Manager](#upload-the-3d-view-as-a-new-asset-to-unity-cloud-asset-manager)
+    - [Upload the 3D view to an existing asset in Unity Cloud Asset Manager](#upload-the-3d-view-to-an-existing-asset-in-unity-cloud-asset-manager)
+    - [Logout from Unity Cloud Asset Manager](#logout-from-unity-cloud-asset-manager)
   - [Troubleshooting](#troubleshooting)
     - [CERTIFICATE\_VERIFY\_FAILED when building the add-on on MacOS](#certificate_verify_failed-when-building-the-add-on-on-macos)
     - [Security limitations](#security-limitations)
@@ -78,24 +81,70 @@ To install the add-on, follow these steps:
 
 ![enabling the add-on](Documentation/Images/enable_addon.png)
 
-### Publish the 3D view as an asset to Unity Cloud Asset Manager
+### Login to Unity Cloud Asset Manager
 
-1. From your 3D view, go to **Unity Cloud** > **Upload FBX to Asset Manager**.
+Follow these steps if is the first time you run the add-on or you have previously logged out (See [Logout from Unity Cloud Asset Manager](#logout-from-unity-cloud-asset-manager) for information about logout). Otherwise, add-on will automatically log in using the previous session.
+1. From your 3D view, go to **Unity Cloud** > **Login**.
+
+![login-to-am](Documentation/Images/login.png)
+
+> **Note**: You will be automatically redirected to the Unity login page. Make sure you complete the login process, until you are redirected to the following page.
+> ![login complete](Documentation/Images/login_complete.png)
+
+2. Go back to Blender.
+
+### Upload the 3D view as a new asset to Unity Cloud Asset Manager
+
+1. Ensure you are logged in to Asset Manager (See [Login to Unity Cloud Asset Manager](#login-to-unity-cloud-asset-manager) for more information about login).
+2. From your 3D view, go to **Unity Cloud** > **Upload FBX to Asset Manager**.
 
 ![opening the add-on](Documentation/Images/open_addon.png)
 
-> **Note**: If this is the first time you run the add-on, you are automatically redirected to the Unity login page. Make sure you complete the login process, until you are redirected to the following page.
-> ![login complete](Documentation/Images/login_complete.png)
-
-2. Go back to Blender. You should now see the `Upload FBX to Asset Manager` popup.
+3. You should now see the `Upload FBX to Asset Manager` popup.
 
 ![popup](Documentation/Images/popup.png)
 
-3. Select a target organization and a project. If you don't have one, you can refer to the [add a new project guide](https://docs.unity.com/cloud/en-us/projects/create-project).
-4. Enter the asset name, description and tags. As part of the export process, this information will be assigned to the asset.
+4. Select a target organization and a project. If you don't have one, you can refer to the [create a new project guide](https://docs.unity.com/cloud/en-us/asset-manager/new-asset-manager-project).
+5. Ensure `<Create new asset>` option is selected in `Asset` dropdown. 
+6. Enter the new asset name, description and tags. As part of the upload process, this information will be assigned to the asset.
 > **Note**: To add multiple tags, simply separate them with a space in-between.
-5. Select **OK**.
-> **Note**: Once the export is complete, you are automatically redirected to the Asset Manager dashboard, so that you can perform additional edit and publish operations from there.
+7. Check `Generate thumbnail` option to create a thumbnail for the asset. Add-on will automatically generate a PNG file and upload it as the asset preview.  
+8. Select **OK**.
+> **Note**: Once the uploading is complete, you are automatically redirected to the Asset Manager dashboard, so that you can perform additional edit and publish operations from there.
+
+### Upload the 3D view to an existing asset in Unity Cloud Asset Manager
+
+1. Ensure you are logged in to Asset Manager (See [Login to Unity Cloud Asset Manager](#login-to-unity-cloud-asset-manager) for more information about login)
+2. From your 3D view, go to **Unity Cloud** > **Upload FBX to Asset Manager**.
+
+![opening the add-on](Documentation/Images/open_addon.png)
+
+3. You should now see the `Upload FBX to Asset Manager` popup.
+
+![popup](Documentation/Images/popup.png)
+
+4. Select a target organization and a project. If you don't have one, you can refer to the [create a new project guide](https://docs.unity.com/cloud/en-us/asset-manager/new-asset-manager-project).
+5. In `Asset` dropdown select the asset you want to update. Add-on will fetch asset name, description and tags.
+> **Note**: During uploading, any existing files in the asset will be removed.
+
+![popup](Documentation/Images/popup_update.png)
+
+6. Change the asset name, description and tags, if needed. As part of the upload process, this information will be assigned to the asset.
+> **Note**: To add multiple tags, simply separate them with a space in-between.
+7. Check `Generate thumbnail` option to create a thumbnail for the asset. Add-on will automatically generate a PNG file and upload it as the asset preview.
+8. Select **OK**.
+> **Note**: Once the uploading is complete, you are automatically redirected to the Asset Manager dashboard, so that you can perform additional edit and publish operations from there.
+
+### Logout from Unity Cloud Asset Manager
+
+1. From your 3D view, go to **Unity Cloud** > **Logout**. Note, this option is only available when you are logged in.
+
+![logout-from-am](Documentation/Images/logout.png)
+
+> **Note**: Once logout completes, you will be automatically redirected to the following page.
+> ![logout complete](Documentation/Images/logout_complete.png)
+
+2. Go back to Blender.
 
 ## Troubleshooting
 
@@ -128,4 +177,4 @@ When building the add-on, the `-dw` option does not perform any integrity protec
 
 ## Tell us what you think!
 
-Thank you for taking a look at the project! To help us improve and provide greater value, please consider providing [feedback on our forum](https://forum.unity.com/forums/unity-cloud.868/) about your experience with AM4 Blender. Thank you!
+Thank you for taking a look at the project! To help us improve and provide greater value, please consider providing feedback in our [Help & Support page](https://cloud.unity.com/home/dashboard-support) about your experience with AM4 Blender. Thank you!

--- a/Scripts/utils.py
+++ b/Scripts/utils.py
@@ -26,7 +26,7 @@ def get_platform_name(system: str, machine: str) -> str:
     return name
 
 
-sdk_version = "0.2.2"
+sdk_version = "0.5.0"
 protocol = "https://"
 domain = "transformation.unity.com"
 url_format = f"{protocol}{domain}/downloads/pythonsdks/release/{sdk_version}/unity_cloud-{sdk_version}-py3-none-{{0}}.whl"

--- a/Source/__init__.py
+++ b/Source/__init__.py
@@ -14,6 +14,12 @@ bl_info = {
 uc_dialog_op_name = "uc_addon.addon_dialog"
 upload_fbx_lbl = "Upload FBX to Asset Manager"
 
+uc_login_op_name = "uc_addon.addon_login"
+login_lbl = "Login"
+
+uc_logout_op_name = "uc_addon.addon_logout"
+logout_lbl = "Logout"
+
 
 class UC_Category(Menu):
     bl_idname = "VIEW3D_MT_UC_category"
@@ -21,42 +27,111 @@ class UC_Category(Menu):
 
     def draw(self, context):
         layout = self.layout
-        layout.operator(uc_dialog_op_name, text=upload_fbx_lbl)
+        from . import uc_asset_manager
+
+        if not uc_asset_manager.is_initialized:
+            uc_asset_manager.initialize()
+
+        if uc_asset_manager.is_logged_in():
+            layout.operator(uc_dialog_op_name, text=upload_fbx_lbl)
+            layout.operator(uc_logout_op_name, text=logout_lbl)
+        else:
+            layout.operator(uc_login_op_name, text=login_lbl)
+
+
+class LoginToCloudOperator(bpy.types.Operator):
+    bl_idname = uc_login_op_name
+    bl_label = login_lbl
+    bl_description = "Login to Asset Manager"
+
+    def execute(self, context):
+        from . import uc_asset_manager
+        uc_asset_manager.login()
+        return {'FINISHED'}
+
+
+class LogoutFromCloudOperator(bpy.types.Operator):
+    bl_idname = uc_logout_op_name
+    bl_label = logout_lbl
+    bl_description = "Logout from Asset Manager"
+
+    def execute(self, context):
+        try:
+            from . import uc_asset_manager
+            uc_asset_manager.logout()
+            uc_asset_manager.uninitialize()
+        finally:
+            global previous_org_id, previous_project_id, previous_asset_idx
+            previous_org_id = None
+            previous_project_id = None
+            previous_asset_idx = None
+        return {'FINISHED'}
 
 
 def on_selected_org_changed(self, context):
-    refresh_projects(self.org_dropdown)
+    refresh_projects(self, context, self.org_dropdown)
+
+    if len(project_items) > 0:
+        self.project_dropdown = project_items[0][0]
+
+
+def on_selected_project_changed(self, context):
+    refresh_assets(self, context, self.org_dropdown, self.project_dropdown)
+
+    if len(assets_items) > 0:
+        self.asset_dropdown = assets_items[0][0]
 
 
 project_items = []
 organization_items = []
+assets_items = []
+assets = {}
+previous_org_id = None
+previous_project_id = None
+previous_asset_idx = None
 
 
-def refresh_orgs():
-    from .uc_asset_manager import get_organizations
+def refresh_orgs(self, context):
+    from . import uc_asset_manager
     orgs = uc_asset_manager.get_organizations()
     items = list()
     for org in orgs:
         items.append((org.id, org.name, f"{org.name}. {org.id}"))
     global organization_items
     organization_items = items
-    org_id = None
-    if len(orgs) > 0:
-        org_id = orgs[0].id
-    refresh_projects(org_id)
 
 
-def refresh_projects(org_id):
-    from .uc_asset_manager import get_projects
+def refresh_projects(self, context, org_id):
+    from . import uc_asset_manager
+    global project_items
+
     if org_id is not None:
         projects = uc_asset_manager.get_projects(org_id)
         items = list()
         for project in projects:
             items.append((project.id, project.name, f"{project.name}. {project.id}"))
-        global project_items
         project_items = items
     else:
         project_items = []
+
+
+def refresh_assets(self, context, org_id, project_id):
+    from . import uc_asset_manager
+    global assets_items, assets
+
+    items = list()
+    assets = {}
+
+    if org_id is not None and project_id is not None:
+        items.append((UploadToCloudOperator.CREATE_ASSET_VALUE, "<Create new asset>", ""))
+        try:
+            assets_array = uc_asset_manager.get_assets(org_id, project_id)
+            for asset in assets_array:
+                items.append((asset.id, asset.name, f"{asset.name}. {asset.id}"))
+                assets[asset.id] = asset
+        except Exception:
+            print(f"Failed to get list from the project {org_id}/{project_id}")
+    assets_items = items
 
 
 def get_organization(self, context):
@@ -66,61 +141,115 @@ def get_organization(self, context):
 def get_projects(self, context):
     return project_items
 
-class ExportToCloudOperator(bpy.types.Operator):
+
+def get_assets(self, context):
+    return assets_items
+
+
+def on_asset_changed(self, context):
+    if self.asset_dropdown == UploadToCloudOperator.CREATE_ASSET_VALUE:
+        self.name_input = UploadToCloudOperator.DEFAULT_ASSET_NAME
+        self.description_input = ""
+        self.tags_input = ""
+    else:
+        global assets
+        asset = assets[self.asset_dropdown]
+        self.name_input = asset.name
+        self.description_input = asset.description if asset.description is not None else ""
+        tags = ""
+        if asset.tags is not None:
+            for tag in asset.tags:
+                tags += f'{tag} '
+        self.tags_input = tags
+
+
+def contains_item(lst, item):
+    return any(triple[0] == item for triple in lst)
+
+
+class UploadToCloudOperator(bpy.types.Operator):
     bl_idname = uc_dialog_op_name
     bl_label = upload_fbx_lbl
+    bl_description = "Create a new asset and upload current scene as *.fbx to Asset Manager"
+    DEFAULT_ASSET_NAME = "New asset"
+    CREATE_ASSET_VALUE = "-1"
 
     org_dropdown: bpy.props.EnumProperty(
-            items=get_organization,
-            name="Organization:",
-            description="Select an organization",
-            default=0,
-            update=on_selected_org_changed,
-        )
+        items=get_organization,
+        name="Organization:",
+        description="Select an organization",
+        update=on_selected_org_changed,
+    )
     project_dropdown: bpy.props.EnumProperty(
-            items=get_projects,
-            name="Project:",
-            description="Select a project",
-            default=0,
-        )
+        items=get_projects,
+        name="Project:",
+        description="Select a project",
+        update=on_selected_project_changed,
+    )
 
-    name_input: bpy.props.StringProperty(name="Asset name:", default="New asset")
+    asset_dropdown: bpy.props.EnumProperty(
+        items=get_assets,
+        name="Asset:",
+        description="Select an asset",
+        update=on_asset_changed,
+    )
+
+    name_input: bpy.props.StringProperty(name="Asset name:", default=DEFAULT_ASSET_NAME)
     description_input: bpy.props.StringProperty(name="Asset description:", default="")
     tags_input: bpy.props.StringProperty(name="Tags:", description="Asset tags separated by spaces: tag1 tag2",
                                          default="")
-    
     generate_preview: bpy.props.BoolProperty(name="Generate thumbnail", default=False)
 
     def execute(self, context):
-        from .uc_blender_utils import uc_addon_execute
         try:
+            name = self.name_input.strip()
             tags = self.tags_input.split()
-            uc_addon_execute(self.org_dropdown, self.project_dropdown, self.name_input, self.description_input,
-                             tags_list=tags, generate_preview=self.generate_preview)
-            self.report({'INFO'}, "Asset was uploaded to Unity Cloud Asset Manager")
+            from . import uc_blender_utils
+
+            if self.asset_dropdown == self.CREATE_ASSET_VALUE:
+                new_asset_id = uc_blender_utils.uc_create_asset(self.org_dropdown, self.project_dropdown,
+                                                                name, self.description_input,
+                                                                tags, self.generate_preview)
+                self.report({'INFO'}, "Asset was created and uploaded to Unity Cloud Asset Manager")
+                refresh_assets(self, context, self.org_dropdown, self.project_dropdown)
+                self.asset_dropdown = new_asset_id
+            else:
+                uc_blender_utils.uc_update_asset(self.org_dropdown, self.project_dropdown,
+                                                 assets[self.asset_dropdown].id,
+                                                 name, self.description_input, tags,
+                                                 self.generate_preview)
+                self.report({'INFO'}, "Asset was updated in Unity Cloud Asset Manager")
         except Exception:
             self.report({'WARNING'}, "Failed to upload asset to Unity Cloud Asset Manager")
             raise
         finally:
-            from .uc_asset_manager import uninitialize
-            uc_asset_manager.uninitialize()
+            global previous_org_id, previous_project_id, previous_asset_idx
+            previous_org_id = self.org_dropdown
+            previous_project_id = self.project_dropdown
+            previous_asset_idx = self.asset_dropdown
         return {'FINISHED'}
 
-    def cancel(self, context):
-        from .uc_asset_manager import uninitialize
-        uc_asset_manager.uninitialize()
-
     def invoke(self, context, event):
-        from .uc_asset_manager import initialize, login
-        uc_asset_manager.initialize()
-        uc_asset_manager.login()
+        from . import uc_asset_manager
+        if not (uc_asset_manager.is_initialized and uc_asset_manager.is_logged_in()):
+            raise Exception("Invalid operation: uc_asset_manager must be initialized and logged in.")
+        refresh_orgs(self, context)
+        global organization_items, previous_org_id, previous_project_id
+        if previous_org_id is not None and contains_item(organization_items, previous_org_id):
+            self.org_dropdown = previous_org_id
 
-        refresh_orgs()
+            if contains_item(project_items, previous_project_id):
+                self.project_dropdown = previous_project_id
+
+                if contains_item(assets_items, previous_asset_idx):
+                    self.asset_dropdown = previous_asset_idx
+        else:
+            self.org_dropdown = organization_items[0][0]
 
         return context.window_manager.invoke_props_dialog(self)
 
 
-classes = (UC_Category, ExportToCloudOperator)
+classes = (UC_Category, UploadToCloudOperator, LoginToCloudOperator, LogoutFromCloudOperator)
 
 
 def draw_func(self, context):
@@ -133,8 +262,14 @@ def register():
         bpy.utils.register_class(cls)
     bpy.types.VIEW3D_MT_editor_menus.append(draw_func)
 
+    from . import uc_asset_manager
+    uc_asset_manager.initialize()
+
 
 def unregister():
+    from . import uc_asset_manager
+    uc_asset_manager.uninitialize()
+
     for cls in classes:
         bpy.utils.unregister_class(cls)
     bpy.types.VIEW3D_MT_editor_menus.remove(draw_func)

--- a/Source/uc_asset_manager.py
+++ b/Source/uc_asset_manager.py
@@ -2,10 +2,19 @@ from typing import List
 import unity_cloud as ucam
 from unity_cloud.models import *
 
+is_initialized = False
+
 
 def initialize():
-    ucam.initialize()
-    ucam.identity.user_login.use()
+    global is_initialized
+    if not is_initialized:
+        ucam.initialize()
+        ucam.identity.user_login.use()
+        is_initialized = True
+
+
+def is_logged_in():
+    return ucam.identity.user_login.get_authentication_state() == ucam.identity.user_login.Authentication_State.LOGGED_IN
 
 
 def login():
@@ -18,22 +27,47 @@ def logout():
         ucam.identity.user_login.logout(True)
 
 
-def export_file_with_preview(path: str, preview_path: str, name: str, description: str,
-                             tags_list: List[str], org_id: str, project_id: str):
+def __upload_file_to_dataset(org_id: str, project_id: str, asset_id: str, version: str, dataset_id: str, upload_file_path: str, cloud_file_path: str):
+    upload_asset = FileUploadInformation(org_id, project_id, asset_id, version, dataset_id, upload_file_path, cloud_file_path)
+    ucam.assets.upload_file(upload_asset)
+
+
+def create_asset(path: str, preview_path: str, name: str, description: str,
+                 tags_list: List[str], org_id: str, project_id: str) -> str:
     asset_creation = AssetCreation(name,
+                                   ucam.assets.AssetType.MODEL_3D,
                                    description,
-                                   ucam.assets.asset_type.MODEL_3D,
                                    tags_list)
 
     asset_id = ucam.assets.create_asset(asset_creation, org_id, project_id)
     version = '1'
     datasets = ucam.assets.get_dataset_list(org_id, project_id, asset_id, version)
-    upload_asset = AssetFileUploadInformation(org_id, project_id, asset_id, version, datasets[0].id, path)
-    ucam.assets.upload_file(upload_asset)
+    __upload_file_to_dataset(org_id, project_id, asset_id, version, datasets[0].id, path, name)
     if preview_path is not None:
-        upload_preview_file = AssetFileUploadInformation(org_id, project_id, asset_id,
-                                                         version, datasets[1].id, preview_path)
-        ucam.assets.upload_file(upload_preview_file)
+        __upload_file_to_dataset(org_id, project_id, asset_id, version, datasets[1].id, preview_path, name + " Preview")
+    ucam.interop.open_browser_to_asset_details(org_id, project_id, asset_id, version)
+    return asset_id
+
+
+def update_asset(path: str, preview_path: str, name: str, description: str,
+                 tags_list: List[str], org_id: str, project_id: str, asset_id: str):
+    version = '1'
+    asset_update = AssetUpdate(name,
+                               ucam.assets.AssetType.MODEL_3D,
+                               description,
+                               tags_list)
+    if ucam.assets.update_asset(asset_update, org_id, project_id, asset_id, version):
+        datasets = ucam.assets.get_dataset_list(org_id, project_id, asset_id, version)
+
+        for asset_dataset in datasets:
+            file_list = ucam.assets.get_file_list(org_id, project_id, asset_id, version, asset_dataset.id)
+            for file in file_list:
+                ucam.assets.remove_file(org_id, project_id, asset_id, version, asset_dataset.id, file.path)
+
+        __upload_file_to_dataset(org_id, project_id, asset_id, version, datasets[0].id, path, name)
+        if preview_path is not None:
+            __upload_file_to_dataset(org_id, project_id, asset_id, version, datasets[1].id, preview_path, name + " Preview")
+
     ucam.interop.open_browser_to_asset_details(org_id, project_id, asset_id, version)
 
 
@@ -45,5 +79,12 @@ def get_projects(org_id: str) -> List[Project]:
     return ucam.identity.get_project_list(org_id)
 
 
+def get_assets(org_id: str, project_id: str) -> List[Asset]:
+    return ucam.assets.get_asset_list(org_id, project_id)
+
+
 def uninitialize():
-    ucam.uninitialize()
+    global is_initialized
+    if is_initialized:
+        ucam.uninitialize()
+        is_initialized = False

--- a/Source/uc_blender_utils.py
+++ b/Source/uc_blender_utils.py
@@ -17,9 +17,9 @@ def _get_preview_image(file_path):
     bpy.ops.render.render(write_still=True)
 
 
-def uc_addon_execute(org_id: str, project_id: str, name: str, description: str,
-                     tags_list: List[str], generate_preview: bool):
-    from .uc_asset_manager import export_file_with_preview
+def uc_create_asset(org_id: str, project_id: str, name: str, description: str,
+                    tags_list: List[str], generate_preview: bool) -> str:
+
     temp_dir = tempfile.mkdtemp()
 
     temp_fbx_file = os.path.join(temp_dir, f"{name}.fbx")
@@ -31,6 +31,25 @@ def uc_addon_execute(org_id: str, project_id: str, name: str, description: str,
             preview_file = os.path.join(temp_dir, "thumbnail.png")
             _get_preview_image(preview_file)
 
-        export_file_with_preview(temp_fbx_file, preview_file, name, description, tags_list, org_id, project_id)
+        from .uc_asset_manager import create_asset
+        return create_asset(temp_fbx_file, preview_file, name, description, tags_list, org_id, project_id)
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+def uc_update_asset(org_id: str, project_id: str, asset_id: str, name: str, description: str, tags_list: List[str],
+                    generate_preview: bool):
+    temp_dir = tempfile.mkdtemp()
+    temp_fbx_file = os.path.join(temp_dir, f"{name}.fbx")
+    try:
+        _export_fbx(temp_fbx_file)
+
+        preview_file = None
+        if generate_preview:
+            preview_file = os.path.join(temp_dir, "thumbnail.png")
+            _get_preview_image(preview_file)
+
+        from . import uc_asset_manager
+        uc_asset_manager.update_asset(temp_fbx_file, preview_file, name, description, tags_list, org_id, project_id, asset_id)
     finally:
         shutil.rmtree(temp_dir)


### PR DESCRIPTION
## [0.2.0] - 2024-02-22

### Added
- Added `Login` and `Logout` buttons to `Unity Cloud` menu.
- Added functionality to select and update an asset in current project.
- Leading and trailing spaces in asset name input string are now removed to comply with validation rules.

### Fixed
- Plugin now recalls previously selected organization and project ids.
- Plugin recalls previously selected organization, project and asset ids only if they are available.
- Removed reference to `InteropException`.

### Changed
- Updated a few URLs in the documentation.
- `unity-cloud` is initialized/uninitialized on add-on registration/unregistration.
- Previously selected organization, project and asset ids are reset after logging out.
- AM4B is now using Unity Cloud Python SDK 0.5.0